### PR TITLE
DIFI 101 Tutorial - Updated OUI

### DIFF
--- a/DIFI_101_Tutorial.md
+++ b/DIFI_101_Tutorial.md
@@ -93,7 +93,7 @@ difi_packet.extend(bytearray.fromhex("00C9")) # C9 is 201 which tells us how man
 
 difi_packet.extend(STREAM_ID.to_bytes(4, 'big'))
           
-difi_packet.extend(bytearray.fromhex("000012A2")) # XX:000012A2  XX:OUI for Vita
+difi_packet.extend(bytearray.fromhex("006A621E")) # XX:006A621E  XX:OUI for Vita
              
 difi_packet.extend(bytearray.fromhex("00000000")) # Info Class Code, Packet Class Code #icc=0x0000,pcc=0x0000
 


### PR DESCRIPTION
Using the old OUI, wireshark dissector is not detecting the packet as a DIFI signal packet, but only as a UDP packet. 
The new OUI is used in both versions 1.1 and 1.2 of DIFI.