### PR TITLE
Fix Wireshark plugin path

### DIFF
--- a/DIFI_101_Tutorial.md
+++ b/DIFI_101_Tutorial.md
@@ -176,7 +176,7 @@ We will now dissect the signal data packet we generated using the code in the pr
 
  If using Linux:
 
-    `~./local/lib/wireshark/plugins`
+    `~/.local/lib/wireshark/plugins`
 
 Run Wireshark, and verify the plugin is loaded under Help->About Wireshark->Plugins.
 


### PR DESCRIPTION
Hello, I was going through the installation of the Wireshark plugin and was a bit confused why it didn't show up in Wireshark.
It's because the default path on Linux is different than what is mentioned in the tutorial. This PR fixes it :)